### PR TITLE
Rails 4.2 Fix fields sanitize().

### DIFF
--- a/lib/xss_terminate.rb
+++ b/lib/xss_terminate.rb
@@ -37,13 +37,7 @@ module XssTerminate
         if xss_terminate_options[:except].include?(field)
           next
         elsif xss_terminate_options[:html5lib_sanitize].include?(field)
-          if  xss_terminate_options[:html5lib_options].empty?
-            self[field] = RailsSanitize.white_list_sanitizer.sanitize(value)
-          elsif xss_terminate_options[:html5lib_options].include?(:whitelist_attrs)
-            self[field] = RailsSanitize.white_list_sanitizer.sanitize(value,
-                           {:attributes => RailsSanitize.white_list_sanitizer.allowed_attributes +
-                             (Set.new(xss_terminate_options[:html5lib_options][:whitelist_attrs].map(&:to_s)))})
-          end
+          self[field] = RailsSanitize.white_list_sanitizer.sanitize(value)
         else
           self[field] = CoupaHelper.coupa_sanitize(value)
         end

--- a/xss_terminate.gemspec
+++ b/xss_terminate.gemspec
@@ -53,5 +53,7 @@ Gem::Specification.new do |s|
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
   end
+
+  s.add_dependency "rails", "~> 4.2.5"
 end
 


### PR DESCRIPTION
- [x] @johnny-lai 
- [x] @edk 

Revert changes from this issue https://coupadev.atlassian.net/browse/CD-1649

In Rails 4.2 Sanitizer white_list include all attributes that we merge in older Rails versions!