### PR TITLE
CD-90843 - Fixes 'uninitialized constant XssTerminate::Formats::AbstractFormat'

### DIFF
--- a/lib/xss_terminate/formats/raw.rb
+++ b/lib/xss_terminate/formats/raw.rb
@@ -1,3 +1,5 @@
+require_relative 'abstract_format'
+
 module XssTerminate
   module Formats
     class Raw < AbstractFormat


### PR DESCRIPTION
## Code Reviewers
- [x] @abdollar  

## Issue

The _Raw_ class wasn't requiring the AbstractFormat class, hence the exception:

```
NameError: uninitialized constant XssTerminate::Formats::AbstractFormat
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/formats/raw.rb:3:in `<module:Formats>'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/formats/raw.rb:2:in `<module:XssTerminate>'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/formats/raw.rb:1:in `<top (required)>'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/formats.rb:11:in `const_get'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/formats.rb:11:in `[]'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/active_record.rb:48:in `xss_terminate_sanitize'
/usr/local/bundle/bundler/gems/xss_terminate-7fdbc1c73eb9/lib/xss_terminate/active_record.rb:41:in `write_attribute_with_type_cast'
```