### PR TITLE
Master Rails 5.0 through 5.2 support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ end
 
 task :test_environment => :environment do
   $:.unshift File.dirname(__FILE__) + "/test"
-  require 'setup_test'
+  require '_setup_test'
 end
 
 desc 'By default, run the unit tests'

--- a/xss_terminate.gemspec
+++ b/xss_terminate.gemspec
@@ -5,38 +5,38 @@
 
 Gem::Specification.new do |s|
   s.name = %q{xss_terminate}
-  s.version = "0.6.1"
+  s.version = '0.6.2'
   s.license = 'MIT'
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Luke Francl", "Bing-Chang Lai"]
+  s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
+  s.authors = ['Luke Francl', 'Bing-Chang Lai']
   s.date = %q{2017-07-21}
   s.description = %q{xss_terminate sanitizes your data before it hits the database so that you don't end up storing XSS attacks. You should still HTML-escape or HTML-sanitize the data before displaying in a HTML page.}
   s.email = %q{look@recursion.org johnny.lai@me.com}
   s.extra_rdoc_files = [
-    "README.rdoc"
+    'README.rdoc'
   ]
 
   file_list = `git ls-files`.split
-  s.files       = file_list
+  s.files = file_list
 
   s.homepage = %q{http://github.com/coupa/xss_terminate}
-  s.rdoc_options = ["--charset=UTF-8"]
-  s.require_paths = ["lib"]
+  s.rdoc_options = ['--charset=UTF-8']
+  s.require_paths = ['lib']
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{xss_terminate sanitizes your data before it hits the database.}
   s.test_files = [
-     "test/models/comment.rb",
-     "test/models/child_entry.rb",
-     "test/models/entry.rb",
-     "test/models/group.rb",
-     "test/models/message.rb",
-     "test/models/person.rb",
-     "test/schema.rb",
-     "test/_setup_test.rb",
-     "test/formats_test.rb",
-     "test/text_sanitizer_test.rb",
-     "test/xss_terminate_test.rb",
+    'test/models/comment.rb',
+    'test/models/child_entry.rb',
+    'test/models/entry.rb',
+    'test/models/group.rb',
+    'test/models/message.rb',
+    'test/models/person.rb',
+    'test/schema.rb',
+    'test/_setup_test.rb',
+    'test/formats_test.rb',
+    'test/text_sanitizer_test.rb',
+    'test/xss_terminate_test.rb'
   ]
 
   if s.respond_to? :specification_version then
@@ -44,10 +44,9 @@ Gem::Specification.new do |s|
     s.specification_version = 3
   end
 
-  s.add_dependency "rails", "~> 4.2.5"
+  s.add_dependency 'rails', ['>= 4.2.5', '~> 5.2.0']
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency('sqlite3')
   s.add_development_dependency 'test-unit', '~> 3.1'
 end
-


### PR DESCRIPTION
Rails removed the method write_attribute_with_type_cast in this PR for Rails 5.1: https://github.com/rails/rails/pull/29464

Then for Rails 5.2, they renamed raw_write_attribute to write_attribute_without_type_cast, and added _write_attribute in this PR: https://github.com/rails/rails/pull/29495

When upgrading to Rails 5.2 this (combined with halt_callback_chains_on_return_false being removed) meant xss_terminate never fully run when setting a sanitized field.

- [x] @johnny-lai 