### PR TITLE
Fix xss_terminate gemspec

### DIFF
--- a/xss_terminate.gemspec
+++ b/xss_terminate.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{xss_terminate}
-  s.version = '0.6.2'
+  s.version = '0.6.3'
   s.license = 'MIT'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
   end
 
-  s.add_dependency 'rails', ['>= 4.2.5', '~> 5.2.0']
+  s.add_dependency 'rails', '>= 4.2.5'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency('sqlite3')


### PR DESCRIPTION
* The current definition does not allow rails to be resolved to the latest 5.1

Bundler could not find compatible versions for gem "activerecord":
  In Gemfile:
    xss_terminate was resolved to 0.6.2, which depends on
      rails (>= 4.2.5, ~> 5.2.0) was resolved to 5.2.0, which depends on
        activerecord (= 5.2.0)

    serialized_attr_encrypted was resolved to 1.2.0, which depends on
      activerecord (< 5.2.0, >= 3.2)

- [x] @IanMcNelly   