### PR TITLE
Resolve an issue in Rails 5.1 with write_attribute

### DIFF
--- a/lib/xss_terminate/active_record.rb
+++ b/lib/xss_terminate/active_record.rb
@@ -11,6 +11,14 @@ module XssTerminate
           self.xss_terminate_options = {}
 
           after_save :xss_terminate_options_clear
+
+          if ::ActiveRecord::AttributeMethods::Write.method_defined? :raw_write_attribute
+            alias raw_write_attribute_without_xss_terminate raw_write_attribute
+            alias raw_write_attribute raw_write_attribute_with_xss_terminate
+
+            alias write_attribute_without_xss_terminate write_attribute
+            alias write_attribute write_attribute_with_xss_terminate
+          end
         end
       end
     end
@@ -45,12 +53,12 @@ module XssTerminate
         end
       elsif ::ActiveRecord::AttributeMethods::Write.method_defined? :raw_write_attribute
         # Rails = 5.1
-        def raw_write_attribute(attr_name, value)
-          super(attr_name, xss_terminate_sanitize(attr_name, value))
+        def raw_write_attribute_with_xss_terminate(attr_name, value)
+          raw_write_attribute_without_xss_terminate(attr_name, xss_terminate_sanitize(attr_name, value))
         end
 
-        def write_attribute(attr_name, value)
-          super(attr_name, xss_terminate_sanitize(attr_name, value))
+        def write_attribute_with_xss_terminate(attr_name, value)
+          write_attribute_without_xss_terminate(attr_name, xss_terminate_sanitize(attr_name, value))
         end
       elsif ::ActiveRecord::AttributeMethods::Write.private_method_defined? :write_attribute_without_type_cast
         # Rails 5.2


### PR DESCRIPTION
We were observing an infinite loop between xss_terminate and delocalize
when upgrading to 5.1 that showed the code jumping between two
overrides of write_attribute. delocalize overrides write_attribute using
alias_method_chain, while xss_terminate uses a plain method override.
I changed xss_terminate to also use alias_method_chain in the 5.1
branch only. This resolve the infinite loop between the two overrides.